### PR TITLE
[deps] update moveit to 125.0.0 SYNC_DATESTAMP: "2024-12-20"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  SYNC_DATESTAMP: "2024-12-05"
+  SYNC_DATESTAMP: "2024-12-20"
   ROS_DISTRO: humble
   VERSION: "125.0.0"
 permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 env:
   SYNC_DATESTAMP: "2024-12-05"
   ROS_DISTRO: humble
-  VERSION: "100.0.5"
+  VERSION: "125.0.0"
 permissions:
   contents: write
   packages: write

--- a/sources.repos
+++ b/sources.repos
@@ -2,7 +2,7 @@ repositories:
   moveit2:
     type: git
     url: https://github.com/JafarAbdi/moveit2.git
-    version: 100.0.5
+    version: 125.0.0
   moveit_msgs:
     type: git
     url: https://github.com/moveit/moveit_msgs.git


### PR DESCRIPTION
update moveit and ros sync_datestamp to the latest

I have confirmed this build works with our system.